### PR TITLE
Create code-of-conduct.md

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,37 @@
+# OpenContainers Code of Conduct
+
+Behave as a community member, follow the code of conduct.
+
+## Code of Conduct
+
+The OpenContainers community is made up of a mixture of professionals and volunteers from all over the world.
+
+When we disagree, we try to understand why.
+Disagreements, both social and technical, happen all the time and OpenContainers is no exception.
+It is important that we resolve disagreements and differing views constructively.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Participants should be aware of these concerns.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+The OpenContainers team does not condone any statements by speakers contrary to these standards.
+The OpenContainers team reserves the right to deny participation any individual found to be engaging in discriminatory or harassing actions.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project.
+
+## Thanks 
+
+Thanks to the [Fedora Code of Conduct](https://getfedora.org/code-of-conduct) and [Contributor Covenant](http://contributor-covenant.org) for inspiration and ideas.
+
+Portions of this Code of Conduct are adapted from the Contributor Covenant, version 1.2.0, available at http://contributor-covenant.org/version/1/2/0/


### PR DESCRIPTION
Copies the code-of-conduct file into the TOB GitHub repository so it could be included (by reference) in other OCI projects rather than being copied into (by value) each project.

Signed-off-by: Rob Dolin <RobDolin@microsoft.com>