### PR TITLE
proposals: Update links to the scope table

### DIFF
--- a/proposals/image-format/README.md
+++ b/proposals/image-format/README.md
@@ -26,7 +26,7 @@ This implies that the OCI Image Format contain sufficient information to launch 
 
 **Q: Why doesn't this project mention distribution?**
 
-A: Distribution, for example using HTTP as both Docker v2.2 and AppC do today, is currently out of scope on the [OCI Scope Table](https://www.opencontainers.org/governance/oci-scope-table). There has been [some discussion on the TOB mailing list]( https://groups.google.com/a/opencontainers.org/d/msg/tob/A3JnmI-D-6Y/tLuptPDHAgAJ) to make distribution an optional layer but this topic is a work in progress.
+A: Distribution, for example using HTTP as both Docker v2.2 and AppC do today, is currently out of scope on the [OCI Scope Table](https://www.opencontainers.org/about/oci-scope-table). There has been [some discussion on the TOB mailing list]( https://groups.google.com/a/opencontainers.org/d/msg/tob/A3JnmI-D-6Y/tLuptPDHAgAJ) to make distribution an optional layer but this topic is a work in progress.
 
 **Q: Why a new project?**
 

--- a/proposals/tools.md
+++ b/proposals/tools.md
@@ -75,4 +75,4 @@ Q: Can additional code/tools be added to the proposed tools repos beyond what is
 A: Yes.  If there is other code or functionality that a contributor believes would be relevant for runtime-related or image-related tools, it would be great if it is contributed.
 
 Q: Does this change the OCI Charter or Scope Table?
-A: No.  Nothing in this proposal is intended to amend the OCI Charter (https://www.opencontainers.org/about/governance) or OCI Scope Table (https://www.opencontainers.org/governance/oci-scope-table).
+A: No.  Nothing in this proposal is intended to amend the OCI Charter (https://www.opencontainers.org/about/governance) or OCI Scope Table (https://www.opencontainers.org/about/oci-scope-table).


### PR DESCRIPTION
At some point this changed from `/governance/` to `/about/`.  @caniszczyk just [updated the charter link][1], so the `/about/` version is probably canonical.

[1]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-02-06.log.html#t2017-02-06T17:48:07