### PR TITLE
distribution: Drop "Related GitHub Issues" section

### DIFF
--- a/proposals/distribution.md
+++ b/proposals/distribution.md
@@ -59,8 +59,3 @@ The API spec is currently considered v2 and we will start the specification at v
 
 * Does this include the code of the docker-registry?
     * No. This is an API specification discussion.
-
-## Related GitHub Issues
-
-* Simplifies tag listing: docker/distribution#2169
-* Allows listing of manifests: docker/distribution#2199


### PR DESCRIPTION
These were added based on @stevvooe's [recommendation][1].  But the new distribution-API maintainers can port those pull-requests over after the project is formed.  Or the docker/distribution maintainers can land them before the new project is formed.  Either way, there's [no need][2] to involve the TOB at this level of detail.

[1]: https://github.com/opencontainers/tob/pull/35#issuecomment-359854860
[2]: https://github.com/opencontainers/tob/pull/35#issuecomment-359927516