### PR TITLE
Loosen restrictions

### DIFF
--- a/proposals/distribution.md
+++ b/proposals/distribution.md
@@ -1,0 +1,61 @@
+# Abstract
+
+The Docker registry protocol has become the defacto standard across the container registry world ([https://github.com/docker/distribution/blob/master/docs/spec/index.md](https://github.com/docker/distribution/blob/master/docs/spec/index.md)).
+
+In the OCI, having a solid, common distribution specification with conformance testing will ensure long lasting security and interoperability throughout the container ecosystem.
+
+## Proposal
+
+TL;DR; Move [https://github.com/docker/distribution/tree/master/docs/spec](https://github.com/docker/distribution/tree/master/docs/spec) to [https://github.com/opencontainers/distribution-spec](https://github.com/opencontainers/distribution-spec)
+
+This proposal covers the distribution API spec, and while it does not cover the code for the docker-registry, that implementation is considered the reference implementation. There are other implementations of this protocol, not all are open-source though (Google gcr.io, Amazon ECR, CoreOS Quay, Gitlab registry, JFrog Artifactory registry, Huawei Dockyard, etc).
+
+In the past when the topic of having an OCI specification around the distribution of container images, it was deferred as "let’s get the image format defined, mean while the industry will settle on a distribution standard". Fast forward, OCI image format is out and adopted, and the Registry v2 is the defacto standard. There is and will be use-cases for alternate methods and the future will likely hold creative ways to push, fetch and share container images, but right now this promotion serves to acknowledge by the OCI the current industry standard of distributing container images.
+
+There is polish that is needed e.g. broken links to storage-driver docs, as well as making sections more generic regarding the OCI descriptors and media-types, but on the whole this is a lateral move.
+
+## Initial Maintainers
+
+* Stephen Day <stephen.day@docker.com> (@stevvooe)
+* Vincent Batts <vbatts@redhat.com> (@vbatts)
+* Derek McGowan <derek.mcgowan@docker.com> (@dmcgowan)
+
+Additional Maintainers to consider:
+
+* Ahmet Alp Balkan (Google)
+* Matt Moore (Google)
+* Yuwa (MSFT)
+* Clayton Coleman (Red Hat)
+* Antonio Murdaca (@runcom) (Red Hat)
+* Samuel Karp (@samuelkarp) (AWS)
+* Mike Brown (IBM)
+* Jimmy Zelinskie jimmy@coreos.com (@jzelinskie)
+* Liu Genping <[liugenping@huawei.com](mailto:liugenping@huawei.com)>
+* Vanessa Sochat (@vsoch)
+
+## Code of Conduct
+
+This project would incorporate (by reference) the OCI Code of Conduct ([https://github.com/opencontainers/tob/blob/master/code-of-conduct.md](https://github.com/opencontainers/tob/blob/master/code-of-conduct.md)).
+
+## Governance and Releases
+
+This project would incorporate the Governance and Releases processes from the OCI project template: [https://github.com/opencontainers/project-template](https://github.com/opencontainers/project-template).
+
+## Project Communications
+
+Both of the proposed projects would continue to use existing channels in use by the OCI developer community for communication including:
+
+* GitHub for issues and pull requests
+* The dev@opencontainers.org email list
+* The monthly OCI developer community conference call
+* The #OpenContainers freenode IRC channel
+
+## Versioning / Roadmap
+
+The API spec is currently considered v2 and we will start the specification at v2.0. Fewer places to change and compare, and it would keep with it being a lateral move.
+
+## Frequently Asked Questions (FAQ)
+
+* Does this include the code of the docker-registry?
+    * No. This is an API specification discussion.
+

--- a/proposals/distribution.md
+++ b/proposals/distribution.md
@@ -1,6 +1,6 @@
 # Abstract
 
-The Docker registry protocol has become the defacto standard across the container registry world ([https://github.com/docker/distribution/blob/master/docs/spec/index.md](https://github.com/docker/distribution/blob/master/docs/spec/index.md)).
+The Docker registry protocol has become the defacto standard across the container registry world ([https://github.com/docker/distribution/blob/master/docs/spec/api.md](https://github.com/docker/distribution/blob/master/docs/spec/api.md)).
 
 In the OCI, having a solid, common distribution specification with conformance testing will ensure long lasting security and interoperability throughout the container ecosystem.
 
@@ -10,7 +10,7 @@ TL;DR; Move [https://github.com/docker/distribution/tree/master/docs/spec](https
 
 This proposal covers the distribution API spec, and while it does not cover the code for the docker-registry, that implementation is considered the reference implementation. There are other implementations of this protocol, not all are open-source though (Google gcr.io, Amazon ECR, CoreOS Quay, Gitlab registry, JFrog Artifactory registry, Huawei Dockyard, etc).
 
-In the past when the topic of having an OCI specification around the distribution of container images, it was deferred as "let’s get the image format defined, mean while the industry will settle on a distribution standard". Fast forward, OCI image format is out and adopted, and the Registry v2 is the defacto standard. There is and will be use-cases for alternate methods and the future will likely hold creative ways to push, fetch and share container images, but right now this promotion serves to acknowledge by the OCI the current industry standard of distributing container images.
+In the past when the topic of having an OCI specification around the distribution of container images was discussed, it was deferred as "let’s get the image format defined, meanwhile the industry will settle on a distribution standard". Fast forward, OCI image format is out and adopted, and the Registry v2 is the defacto standard. There is and will be use-cases for alternate methods and the future will likely hold creative ways to push, fetch and share container images, but right now this promotion serves to acknowledge by the OCI the current industry standard of distributing container images.
 
 There is polish that is needed e.g. broken links to storage-driver docs, as well as making sections more generic regarding the OCI descriptors and media-types, but on the whole this is a lateral move.
 
@@ -31,7 +31,7 @@ Additional Maintainers to consider:
 * Mike Brown (IBM)
 * Jimmy Zelinskie jimmy@coreos.com (@jzelinskie)
 * Liu Genping <[liugenping@huawei.com](mailto:liugenping@huawei.com)>
-* Vanessa Sochat (@vsoch)
+* Vanessa Sochat (@vsoch) (Stanford) <vsochat@stanford.edu>
 
 ## Code of Conduct
 
@@ -59,3 +59,7 @@ The API spec is currently considered v2 and we will start the specification at v
 * Does this include the code of the docker-registry?
     * No. This is an API specification discussion.
 
+## Related GitHub Issues
+
+* Simplifies tag listing: docker/distribution#2169
+* Allows listing of manifests: docker/distribution#2199

--- a/proposals/distribution.md
+++ b/proposals/distribution.md
@@ -4,6 +4,8 @@ The Docker registry protocol has become the defacto standard across the containe
 
 In the OCI, having a solid, common distribution specification with conformance testing will ensure long lasting security and interoperability throughout the container ecosystem.
 
+This proposal also provides the container ecosystem with a means to discuss and schedule extensions to the distribution specification.
+
 ## Proposal
 
 TL;DR; Move [`api.md`][api.md] to a new [distribution-spec project](https://github.com/opencontainers/distribution-spec).
@@ -107,16 +109,10 @@ The following entries should be added to the [scope table][scope]:
     Retrieving images covers the current “tag listing” (e.g. “what named manifests are in `library/busybox`?”), because tags are entries in the image format's [`manifests` array][manifests].
     Other tag-listing endpoints needed for backwards-compatibility are therefore in scope as well.
 
-    Repository actions and listing images within a repository are considered part of distribution policy or content management and are out of scope for this entry's per-image action.
-    For example, “what images are under `library/`?” is out of scope for this project.
-
     * What: Specifying a distribution method
     * In/Out/Future: In scope
     * Status: In progress (see opencontainers/distribution-spec)
     * Description: Define a protocol for image, manifest, config, and blob creation, retrieval, and deletion.
-        Listing repositories is a multi-repository action, which is out of scope for this entry.
-        Creating and deleting repositories are per-repository actions, which are out of scope for this entry.
-        Listing images within repositories is a per-repository action, which is out of scope for this entry.
     * Why: This specification will provide one (of possibly many) distribution specifications.
         Alternative distribution specifications may be developed for uses cases not covered by this specification, but defining them is currently out of scope for the OCI.
 


### PR DESCRIPTION
This commit removes a few of the restrictions placed on the distribution method proposed in #35. For example, the maintainers should have the freedom to explore adding image listing protocols to go along with the protocols for image, manifest, config, and blob creation, retrieval, and deletion.
