### PR TITLE
distribution: Change from blame to rendered URI for image-index

### DIFF
--- a/proposals/distribution.md
+++ b/proposals/distribution.md
@@ -146,7 +146,7 @@ The following entries should remain in the [scope table][scope] but not be addre
 [get-manifest]: https://github.com/docker/distribution/blob/5cb406d511b7b9163bff9b6439072e4892e5ae3b/docs/spec/api.md#pulling-an-image-manifest
 [iana-auth]: http://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
 [image-spec]: https://github.com/opencontainers/image-spec/
-[image-index]: https://github.com/opencontainers/image-spec/blame/v1.0.1/image-index.md
+[image-index]: https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md
 [manifest]: https://github.com/opencontainers/image-spec/blob/v1.0.1/manifest.md
 [manifests]: https://github.com/opencontainers/image-spec/blame/v1.0.1/image-index.md#L23
 [rfc6750]: https://tools.ietf.org/html/rfc6750


### PR DESCRIPTION
We only need blame views when the Markdown does not provide a specific-enough anchor, and this is a link to the whole file.

Fixes the issue raised be @stevvooe [here][1].

[1]: https://github.com/opencontainers/tob/pull/35#discussion_r172689573