### PR TITLE
Clean up language around tag listing and repository naming

### DIFF
--- a/proposals/distribution.md
+++ b/proposals/distribution.md
@@ -104,6 +104,7 @@ The following entries should be added to the [scope table][scope]:
     This entry replaces part of the previous “Creating Reference spec for optional DNS based naming & distribution” and “Standardizing on a particular Distribution method” entries.
 
     Tag-listing (e.g. “what named manifests are in `library/busybox`?”) endpoints are in scope and required for backwards compatibility with clients.
+    An endpoint for listing image repository names within a registry is considered out of scope for this specification.
 
     Managing the grouping of image repository names is considered part of distribution policy or content management, which are out of scope.
     For example, “which image repositories are under `library/`?” is out of scope for this project.
@@ -111,10 +112,7 @@ The following entries should be added to the [scope table][scope]:
     * What: Specifying a distribution method
     * In/Out/Future: In scope
     * Status: In progress (see opencontainers/distribution-spec)
-    * Description: Define a protocol for creating, retrieving, updating, and deleting objects defined in the [image specification][image-spec].
-        Listing repositories (like [`/v2/_catalog`][catalog]) is a multi-[image-index][] action, which is out of scope for this entry.
-        Managing groups of image indexes requires multi-[image-index][] actions, which are out of scope for this entry.
-        Listing image indexes within a group is a multi-[image-index][] action, which is out of scope for this entry.
+    * Description: Define a protocol for creating, retrieving, updating, and deleting content-addressable objects, such as those defined in the [image specification][image-spec].
     * Why: This specification will provide one (of possibly many) distribution specifications.
         Alternative distribution specifications may be developed for uses cases not covered by this specification, but defining them is currently out of scope for the OCI.
 

--- a/proposals/distribution.md
+++ b/proposals/distribution.md
@@ -103,11 +103,10 @@ The following entries should be added to the [scope table][scope]:
 * “Specifying a distribution method”.
     This entry replaces part of the previous “Creating Reference spec for optional DNS based naming & distribution” and “Standardizing on a particular Distribution method” entries.
 
-    Retrieving image indexes covers the current “tag listing” (e.g. “what named manifests are in `library/busybox`?”), because tags are entries in the image format's [`manifests` array][manifests].
-    Other tag-listing endpoints needed for backwards-compatibility are therefore in scope as well.
+    Tag-listing (e.g. “what named manifests are in `library/busybox`?”) endpoints are in scope and required for backwards compatibility with clients.
 
-    Grouping image indexes in repositories is considered part of distribution policy or content management, which are out of scope for this entry's per-image action.
-    For example, “what images are under `library/`?” is out of scope for this project.
+    Managing the grouping of image repository names is considered part of distribution policy or content management, which are out of scope.
+    For example, “which image repositories are under `library/`?” is out of scope for this project.
 
     * What: Specifying a distribution method
     * In/Out/Future: In scope


### PR DESCRIPTION
Tag listing should mention the endpoints and external methods relying on content addressability.
Image repositories should not be referred to as indexes, but rather as image repositories.