### PR TITLE
README: Use relative links to the proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ https://groups.google.com/a/opencontainers.org/forum/#!forum/tob (tob@opencontai
 
 ## Project Proposals
 
-* [Digest](https://github.com/opencontainers/tob/blob/master/proposals/digest.md)
-* [Distribution Spec](https://github.com/opencontainers/tob/blob/master/proposals/distribution.md)
-* [Image Format Spec](https://github.com/opencontainers/tob/tree/master/proposals/image-format)
-* [SELinux](https://github.com/opencontainers/tob/blob/master/proposals/selinux.md)
-* [Tools](https://github.com/opencontainers/tob/blob/master/proposals/tools.md)
+* [Digest](proposals/digest.md)
+* [Distribution Spec](proposals/distribution.md)
+* [Image Format Spec](proposals/image-format)
+* [SELinux](proposals/selinux.md)
+* [Tools](proposals/tools.md)
 
 ## Voting
 


### PR DESCRIPTION
There's no need to use absolute links for these.  And using relative links sets a good example for future proposals, because the links will work in the proposal branch's README before the referenced proposal lands in the TOB master.

There's a similar absolute link for the code-of-conduct in the distribution proposal.  The intention may have been to show the absolute URL which would be included in new project's repository.  I don't think that matters, because the project template has included a similar link since opencontainers/project-template@ee72bc89 (opencontainers/project-template#45), so I've left that alone here.