### PR TITLE
CHARTER: Add WG proposal and templates

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,10 +1,11 @@
-# Open Container Initiative Charter v1.2
+# Open Container Initiative Charter v1.3
 
-| Comment          | Effective Date   |
-| ---------------- |:----------------:|
-| Initial release  | 13 November 2015 |
-| Update           | 18 May 2020      |
-| Update (simplify)| 4 June 2020      |
+| Comment           | Effective Date   |
+| ----------------- |:----------------:|
+| Initial release   | 13 November 2015 |
+| Update            | 18 May 2020      |
+| Update (simplify) | 4 June 2020      |
+| Add Working Groups| **TBD**          |
 
 ##  1. Mission of the Open Container Initiative (“OCI”).
 
@@ -308,6 +309,47 @@ n. The intention is for the TOB to operate by consensus. However, if consensus
 o. Any issues that cannot be resolved by the TOB shall be referred to The Linux
    Foundation Executive Director for mediation, and, if necessary, for
    resolution by The Linux Foundation Board of Directors.
+
+p. OCI Working Groups.
+
+   - i. The OCI may establish one or more working groups (each, an “OCI Working
+     Group”) to experiment, validate, and define new OCI Specifications or
+     major revisions to existing OCI Specifications. Each OCI Working Group
+     shall have a defined scope of the OCI Working Group's intended activities
+     and goals. The end result of the OCI Working Group's work product shall be
+     either a new OCI Specification, an update to an existing OCI
+     Specification, or a new OCI Project.
+
+   - ii. Any participant in the OCI technical community may propose a working
+     group to the TOB for consideration. The TOB shall maintain a public list
+     of the information required to be included in a working group proposal.
+
+   - iii. Approval of a new OCI Working Group requires a two-thirds vote of the
+     TOB. The TOB will maintain a public list of all approved OCI Working
+     Groups.
+
+   - iv. Once an OCI Working Group determines that it has achieved its
+     objectives, the OCI Working Group leaders shall present to the TOB the
+     draft specification or project, along with such other information as the
+     TOB may require for evaluation of the draft specification or project. The
+     TOB shall maintain a public list of such required information.
+
+   - v. Approval of the draft specification (to be released as an OCI
+     Specification) or draft project (to become an OCI Project) shall require a
+     two-thirds vote of the TOB. For a draft specification, prior to such
+     approval the OCI Working Group may not describe it as a released OCI
+     Specification, and must designate it with a `-draft.#` suffix.
+
+   - vi. Following TOB approval of a draft specification to be released as an
+     OCI Specification, the OCI Specification's maintainers may determine the
+     process for making subsequent releases, provided that (1) such process is
+     subject to TOB review, approval and modification, and (2) following any
+     release of a new version of an OCI Specification, OCI shall notify all
+     Members as set forth in Section 8(d) of this Charter.
+
+   - vii. The TOB may, by a two-thirds vote, elect to disband an OCI Working
+     Group in its discretion, including if the TOB determines that the OCI
+     Working Group has not made meaningful progress or has become inactive.
 
 ## 7. OCI Values.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -317,8 +317,13 @@ p. OCI Working Groups.
      major revisions to existing OCI Specifications. Each OCI Working Group
      shall have a defined scope of the OCI Working Group's intended activities
      and goals. The end result of the OCI Working Group's work product shall be
-     either a new OCI Specification, an update to an existing OCI
-     Specification, or a new OCI Project.
+     either:
+       - an update to an existing OCI Specification (for example, adding
+         support for a new set of features);
+       - a new OCI Specification (for example, creating an OCI Specification
+         for a new topical area); or
+       - a new OCI Project other than a Specification (for example, creating a
+         reference implementation of an OCI Specification).
 
    - ii. Any participant in the OCI technical community may propose a working
      group to the TOB for consideration. The TOB shall maintain a public list
@@ -330,14 +335,14 @@ p. OCI Working Groups.
 
    - iv. Once an OCI Working Group determines that it has achieved its
      objectives, the OCI Working Group leaders shall present to the TOB the
-     draft specification or project, along with such other information as the
-     TOB may require for evaluation of the draft specification or project. The
-     TOB shall maintain a public list of such required information.
+     draft specification or other project, along with such other information as
+     the TOB may require for evaluation of the draft specification or other
+     project. The TOB shall maintain a public list of such required information.
 
    - v. Approval of the draft specification (to be released as an OCI
-     Specification) or draft project (to become an OCI Project) shall require a
-     two-thirds vote of the TOB. For a draft specification, prior to such
-     approval the OCI Working Group may not describe it as a released OCI
+     Specification) or other draft project (to become an OCI Project) shall
+     require a two-thirds vote of the TOB. For a draft specification, prior to
+     such approval the OCI Working Group may not describe it as a released OCI
      Specification, and must designate it with a `-draft.#` suffix.
 
    - vi. Following TOB approval of a draft specification to be released as an
@@ -347,9 +352,13 @@ p. OCI Working Groups.
      release of a new version of an OCI Specification, OCI shall notify all
      Members as set forth in Section 8(d) of this Charter.
 
-   - vii. The TOB may, by a two-thirds vote, elect to disband an OCI Working
-     Group in its discretion, including if the TOB determines that the OCI
-     Working Group has not made meaningful progress or has become inactive.
+   - vii. The TOB may, by a two-thirds vote, approve requests from the owners
+     of an OCI Working Group to (a) amend the OCI Working Group's governance
+     document, or (b) adjust the composition of the owners or maintainers of
+     that OCI Working Group. The TOB may also, by a two-thirds vote, elect to
+     disband an OCI Working Group in its discretion, including if the TOB
+     determines that the OCI Working Group has not made meaningful progress or
+     has become inactive.
 
 ## 7. OCI Values.
 

--- a/WG-INFO.md
+++ b/WG-INFO.md
@@ -3,7 +3,8 @@
 ## List of current OCI Working Groups
 
 * OCI Working Groups approved by the TOB will be listed here, along with each
-  Working Group's maintainers.
+  Working Group's owners and, where applicable following approval of a draft
+  as an OCI Specification, the Working Group's maintainers.
 
 ## List of disbanded OCI Working Groups
 
@@ -18,9 +19,9 @@ OCI Working Group proposals should contain the following information:
 1. a list of owners who have agreed to participate in the working group, review
    progress, report progress back to the OCI community, and present the results
    to the TOB once the working group has completed its objectives
-1. a list of projects or organizations sponsoring the working group and
-   participating in the implementation and use case validation of the work done
-   by the group
+1. a list of OCI Projects, non-OCI projects, or organizations sponsoring the
+   working group and participating in the implementation and use case
+   validation of the work done by the group
 1. a set of project rules which govern how contributions to the working group
    will be handled and decisions will be made
 1. a working agreement for making progress, which may include weekly meetings,
@@ -32,15 +33,15 @@ OCI Working Group proposals should contain the following information:
 
 When an OCI Working Group determines that it has completed its initial work and
 is prepared to request TOB approval for the initial release of its outputs as
-an OCI Specification or an OCI Project, the OCI Working Group maintainers will
+an OCI Specification or other OCI Project, the OCI Working Group owners will
 present to the TOB the following:
 
 * the draft specification or project content
 * the validation work which demonstrates real world usability
 * the set of maintainers who have agreed to carry the specification forward
 
-There is no requirement that maintainers or contributors to the OCI Working
-Group will continue to be maintainers for an approved OCI Specification or OCI
+There is no requirement that owners or contributors to the OCI Working Group
+will continue to be maintainers for an approved OCI Specification or other OCI
 Project after TOB approval and release. However, the TOB will consider it a
-requirement that any OCI Specification or OCI Project has a dedicated and
-active group of maintainers to continue the work.
+requirement that any approved OCI Specification or other OCI Project has a dedicated
+and active group of maintainers to continue the work.

--- a/WG-INFO.md
+++ b/WG-INFO.md
@@ -1,0 +1,46 @@
+# OCI Working Groups
+
+## List of current OCI Working Groups
+
+* OCI Working Groups approved by the TOB will be listed here, along with each
+  Working Group's maintainers.
+
+## List of disbanded OCI Working Groups
+
+* OCI Working Groups disbanded by the TOB will be listed here.
+
+## Required information for OCI Working Group Proposals
+
+OCI Working Group proposals should contain the following information:
+
+1. a clearly defined objective and scope of what the working groups aims to
+   accomplish
+1. a list of owners who have agreed to participate in the working group, review
+   progress, report progress back to the OCI community, and present the results
+   to the TOB once the working group has completed its objectives
+1. a list of projects or organizations sponsoring the working group and
+   participating in the implementation and use case validation of the work done
+   by the group
+1. a set of project rules which govern how contributions to the working group
+   will be handled and decisions will be made
+1. a working agreement for making progress, which may include weekly meetings,
+   dedicated channels for discussions, or a shared repository
+1. a request for OCI resources, which may include recurring meetings in the OCI
+   calendar, OCI hosted repository, or topic specific communication channels
+
+## Required information for TOB Release Approval
+
+When an OCI Working Group determines that it has completed its initial work and
+is prepared to request TOB approval for the initial release of its outputs as
+an OCI Specification or an OCI Project, the OCI Working Group maintainers will
+present to the TOB the following:
+
+* the draft specification or project content
+* the validation work which demonstrates real world usability
+* the set of maintainers who have agreed to carry the specification forward
+
+There is no requirement that maintainers or contributors to the OCI Working
+Group will continue to be maintainers for an approved OCI Specification or OCI
+Project after TOB approval and release. However, the TOB will consider it a
+requirement that any OCI Specification or OCI Project has a dedicated and
+active group of maintainers to continue the work.

--- a/WG-TEMPLATE.md
+++ b/WG-TEMPLATE.md
@@ -1,0 +1,47 @@
+# OCI Working Group Template
+
+The following is a template that the TOB and/or proposers of a new OCI Working Group may use to document the intended scope and activities of the OCI Working Group following its establishment. {Bracketed sections below} should be filled in with the Working Group's specific details.
+
+# {WG NAME} OCI Working Group - Governance Charter
+
+This document describes the basic governance principles for the {WG NAME} Working Group (the “WG”).
+
+The WG operates as an OCI Working Group under the [Open Container Initiative (OCI) Charter](https://github.com/opencontainers/tob/blob/master/CHARTER.md), which describes the responsibilities of the OCI Technical Oversight Board (the "TOB”). The WG is established by the TOB as an OCI Working Group pursuant to the OCI Charter. Accordingly, the WG will operate in accordance with the OCI Charter and OCI's other policies and procedures, supplemented by the details below.
+
+## Purpose
+
+{Briefly describe the purpose of the WG.}
+
+## Scope
+
+* {Describe the activities and work that are in scope for the WG.}
+
+## Out of Scope
+
+* {Where helpful for clarity or to avoid confusion, describe any activities or topics that are out of scope for the WG.}
+
+## Intended work product
+
+* {Describe the intended work product and outputs of the WG, particularly indicating whether they consist of specification(s) and/or project(s).}
+
+## Governance
+
+* **Working Group**:
+  * The TOB is establishing the WG as an OCI Working Group, pursuant to section 6(p) of the OCI Charter.
+* **Maintainers**:
+  * The TOB will appoint one or more initial maintainers of the WG.
+  * The TOB may, in its discretion, remove and/or appoint new maintainers of the WG.
+  * The current maintainers will be listed in the [OCI Working Group documentation](https://github.com/opencontainers/tob/blob/master/WG-INFO.md).
+  * The maintainers shall be responsible for:
+    * scheduling regular meetings of the WG community;
+    * facilitating open discussion among WG community participants;
+    * coordinating and managing the development of the WG work product and outputs;
+    * recording decisions that are reached by the WG community; and
+    * keeping the TOB regularly informed about the status of the WG’s efforts, including when the WG has readied the work product and outputs for TOB approval.
+* **Meetings**:
+  * Meetings of the WG shall be open to the public.
+  * Participants in the meetings shall comply with the [OCI Code of Conduct](https://github.com/opencontainers/.github/blob/master/CODE_OF_CONDUCT.md) and all other policies of OCI and The Linux Foundation.
+* **TOB Approval**:
+  * The WG shall operate pursuant to the procedures set forth in section 6(p) of the OCI Charter, with regards to obtaining TOB approval for initial release of the work product and outputs as an OCI Specification or OCI Project, and for subsequent maintenance activities thereafter.
+* **Amendments**:
+  * The TOB may, in its discretion, amend this WG Governance Document from time to time.

--- a/WG-TEMPLATE.md
+++ b/WG-TEMPLATE.md
@@ -22,26 +22,31 @@ The WG operates as an OCI Working Group under the [Open Container Initiative (OC
 
 ## Intended work product
 
-* {Describe the intended work product and outputs of the WG, particularly indicating whether they consist of specification(s) and/or project(s).}
+* {Describe the intended work product and outputs of the WG, particularly indicating whether they consist of specification(s) and/or other project(s).}
 
 ## Governance
 
 * **Working Group**:
-  * The TOB is establishing the WG as an OCI Working Group, pursuant to section 6(p) of the OCI Charter.
-* **Maintainers**:
-  * The TOB will appoint one or more initial maintainers of the WG.
-  * The TOB may, in its discretion, remove and/or appoint new maintainers of the WG.
-  * The current maintainers will be listed in the [OCI Working Group documentation](https://github.com/opencontainers/tob/blob/master/WG-INFO.md).
-  * The maintainers shall be responsible for:
+  * The TOB is establishing the WG as an OCI Working Group, pursuant to [section 6(p)](https://github.com/opencontainers/tob/blob/master/CHARTER.md#6-technical-oversight-board-tob) of the OCI Charter.
+* **Owners**:
+  * The WG proposal to the TOB will specify one or more initial "owners" of the WG.
+  * The current owners will be listed in the [OCI Working Group documentation](https://github.com/opencontainers/tob/blob/master/WG-INFO.md).
+  * The owners shall be responsible for:
     * scheduling regular meetings of the WG community;
     * facilitating open discussion among WG community participants;
     * coordinating and managing the development of the WG work product and outputs;
     * recording decisions that are reached by the WG community; and
     * keeping the TOB regularly informed about the status of the WG’s efforts, including when the WG has readied the work product and outputs for TOB approval.
+* **Maintainers**:
+  * If the WG owners request the TOB to approve a draft specification as a released OCI Specification, the request shall include a list of proposed "maintainers" of the OCI Specification.
+  * The current maintainers will be listed in the [OCI Working Group documentation](https://github.com/opencontainers/tob/blob/master/WG-INFO.md).
+  * The maintainers shall be responsible for continuing the work of overseeing updates, improvements and changes to a released OCI Specification on an ongoing basis.
 * **Meetings**:
   * Meetings of the WG shall be open to the public.
   * Participants in the meetings shall comply with the [OCI Code of Conduct](https://github.com/opencontainers/.github/blob/master/CODE_OF_CONDUCT.md) and all other policies of OCI and The Linux Foundation.
 * **TOB Approval**:
-  * The WG shall operate pursuant to the procedures set forth in section 6(p) of the OCI Charter, with regards to obtaining TOB approval for initial release of the work product and outputs as an OCI Specification or OCI Project, and for subsequent maintenance activities thereafter.
+  * The WG shall operate pursuant to the procedures set forth in [section 6(p)](https://github.com/opencontainers/tob/blob/master/CHARTER.md#6-technical-oversight-board-tob) of the OCI Charter, with regards to obtaining TOB approval for initial release of the work product and outputs as an OCI Specification or other OCI Project, and for subsequent maintenance activities thereafter.
 * **Amendments**:
-  * The TOB may, in its discretion, amend this WG Governance Document from time to time.
+  * The owners of the WG may from time to time propose to the TOB (1) amendments to this WG Governance Document, and/or (2) changes to the composition of the owners or maintainers of the WG.
+  * As set forth in the OCI Charter, the TOB may, in its discretion by a two-thirds vote, approve or reject the requested amendments or changes.
+  * As set forth in the OCI Charter, the TOB may also disband the WG by a two-thirds vote.


### PR DESCRIPTION
(cc @caniszczyk)

This is a revised version of the OCI Working Group Draft Proposal for consideration by the TOB.

I've reworked the draft proposal somewhat, moving some details (such as lists of specific info that the TOB would require for review) into a separate `WG-INFO.md` document. That way those pieces of information could be modified by the TOB in its discretion, without requiring a subsequent formal charter amendment.

I've also made some proposed edits to the language of what remains in the charter portion, I'd encourage folks to please review closely. A minor note, I've also shifted the Working Group content into section 6(p) rather than as a new section 7, to avoid having to do lots of renumbering for the rest of the charter.

Finally, I'm including a `WG-TEMPLATE.md` document which could be used by the TOB as a way to document the scope / work product and ways of working for each new WG, but the TOB could of course modify or omit this altogether if it doesn't like this approach.

If the TOB does elect to proceed with adopting this, please note the procedure in section 12(a) of the OCI Charter for adopting charter amendments, including the required period of notice to members.

Signed-off-by: Steve Winslow <steve@swinslow.net>