### PR TITLE
Working group for Reference Spec

### DIFF
--- a/proposals/wg-reference-spec.md
+++ b/proposals/wg-reference-spec.md
@@ -1,0 +1,74 @@
+# OCI Working Group: Reference Spec
+
+# Reference Spec OCI Working Group - Governance Charter
+
+This document describes the basic governance principles for the Reference Spec Working Group (the “WG”).
+
+The WG operates as an OCI Working Group under the [Open Container Initiative (OCI) Charter](https://github.com/opencontainers/tob/blob/master/CHARTER.md), which describes the responsibilities of the OCI Technical Oversight Board (the "TOB”). The WG is established by the TOB as an OCI Working Group pursuant to the OCI Charter. Accordingly, the WG will operate in accordance with the OCI Charter and OCI's other policies and procedures, supplemented by the details below.
+
+## Purpose
+
+References are a string that is used by runtimes and other OCI registry clients to retrieve a container image.
+They are currently a convention, used by many clients, adopted from Docker and implemented in distribution/distribution.
+This WG seeks to define the syntax and parsing of a reference as an OCI spec.
+
+## Scope
+
+* Document the existing convention used by runtimes and other OCI registry clients.
+* Specify the syntax for references to an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/7b36cea86235157d78528944cb94c3323ee0905c/image-layout.md) manifest, including support for a tag, digest, or a full registry/repository name.
+* Define how the syntax can be extended to support other use cases, including:
+  * Alternate layer formats
+  * Immutable tags
+  * Selecting an artifact that refers to another manifest (e.g. signature or SBOM)
+  * Querying content from a pull through cache serving multiple registries (see [distribution-spec PR #66](https://github.com/opencontainers/distribution-spec/pull/66))
+* Provide backwards compatibility by using the existing reference convention from [distribution/reference](https://github.com/distribution/reference) when feasible.
+
+## Out of Scope
+
+* This WG will be limited to the creation of a new spec, and is not expected to impact other OCI specs.
+
+## Intended work product
+
+* Create a `reference-spec` with a formal specification for parsing a reference string.
+* Provide a Go implementation of the spec.
+
+## Proposed Owners
+
+The following have agreed to participate in the working group, review progress, report progress back to the OCI community, and present the results to the TOB once the working group has completed its objectives.
+
+* Brandon Mitchell
+* **additional volunteers needed**
+
+## Stakeholders
+
+OCI Projects, non-OCI projects, or organizations sponsoring the working group and participating in the implementation and use case validation of the work done by the group.
+
+* regclient
+* **additional volunteers needed**
+
+## Governance
+
+* **Working Group**:
+  * The TOB is establishing the WG as an OCI Working Group, pursuant to [section 6(p)](https://github.com/opencontainers/tob/blob/master/CHARTER.md#6-technical-oversight-board-tob) of the OCI Charter.
+* **Owners**:
+  * The WG proposal to the TOB will specify one or more initial "owners" of the WG.
+  * The current owners will be listed in the [OCI Working Group documentation](https://github.com/opencontainers/tob/blob/master/WG-INFO.md).
+  * The owners shall be responsible for:
+    * scheduling regular meetings of the WG community;
+    * facilitating open discussion among WG community participants;
+    * coordinating and managing the development of the WG work product and outputs;
+    * recording decisions that are reached by the WG community; and
+    * keeping the TOB regularly informed about the status of the WG’s efforts, including when the WG has readied the work product and outputs for TOB approval.
+* **Maintainers**:
+  * If the WG owners request the TOB to approve a draft specification as a released OCI Specification, the request shall include a list of proposed "maintainers" of the OCI Specification.
+  * The current maintainers will be listed in the [OCI Working Group documentation](https://github.com/opencontainers/tob/blob/master/WG-INFO.md).
+  * The maintainers shall be responsible for continuing the work of overseeing updates, improvements and changes to a released OCI Specification on an ongoing basis.
+* **Meetings**:
+  * Meetings of the WG shall be open to the public.
+  * Participants in the meetings shall comply with the [OCI Code of Conduct](https://github.com/opencontainers/.github/blob/master/CODE_OF_CONDUCT.md) and all other policies of OCI and The Linux Foundation.
+* **TOB Approval**:
+  * The WG shall operate pursuant to the procedures set forth in [section 6(p)](https://github.com/opencontainers/tob/blob/master/CHARTER.md#6-technical-oversight-board-tob) of the OCI Charter, with regards to obtaining TOB approval for initial release of the work product and outputs as an OCI Specification or other OCI Project, and for subsequent maintenance activities thereafter.
+* **Amendments**:
+  * The owners of the WG may from time to time propose to the TOB (1) amendments to this WG Governance Document, and/or (2) changes to the composition of the owners or maintainers of the WG.
+  * As set forth in the OCI Charter, the TOB may, in its discretion by a two-thirds vote, approve or reject the requested amendments or changes.
+  * As set forth in the OCI Charter, the TOB may also disband the WG by a two-thirds vote.

--- a/proposals/wg-reference-spec.md
+++ b/proposals/wg-reference-spec.md
@@ -36,13 +36,17 @@ This WG seeks to define the syntax and parsing of a reference as an OCI spec.
 
 The following have agreed to participate in the working group, review progress, report progress back to the OCI community, and present the results to the TOB once the working group has completed its objectives.
 
+* Akihiro Suda
 * Brandon Mitchell
+* James Hewitt
+* Vishal Choudhary
 * **additional volunteers needed**
 
 ## Stakeholders
 
 OCI Projects, non-OCI projects, or organizations sponsoring the working group and participating in the implementation and use case validation of the work done by the group.
 
+* distribution
 * regclient
 * **additional volunteers needed**
 

--- a/proposals/wg-reference-spec.md
+++ b/proposals/wg-reference-spec.md
@@ -1,6 +1,6 @@
 # OCI Working Group: Reference Spec
 
-# Reference Spec OCI Working Group - Governance Charter
+## Reference Spec OCI Working Group - Governance Charter
 
 This document describes the basic governance principles for the Reference Spec Working Group (the “WG”).
 
@@ -46,7 +46,11 @@ The following have agreed to participate in the working group, review progress, 
 
 OCI Projects, non-OCI projects, or organizations sponsoring the working group and participating in the implementation and use case validation of the work done by the group.
 
+* buildkit
+* containerd
 * distribution
+* nerdctl
+* moby
 * regclient
 * **additional volunteers needed**
 

--- a/proposals/wg-reference-spec.md
+++ b/proposals/wg-reference-spec.md
@@ -10,18 +10,25 @@ The WG operates as an OCI Working Group under the [Open Container Initiative (OC
 
 References are a string that is used by runtimes and other OCI registry clients to retrieve a container image.
 They are currently a convention, used by many clients, adopted from Docker and implemented in distribution/distribution.
-This WG seeks to define the syntax and parsing of a reference as an OCI spec.
+This WG seeks to document the syntax and parsing of a reference within the OCI.
 
 ## Scope
 
 * Document the existing convention used by runtimes and other OCI registry clients.
-* Specify the syntax for references to an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/7b36cea86235157d78528944cb94c3323ee0905c/image-layout.md) manifest, including support for a tag, digest, or a full registry/repository name.
-* Define how the syntax can be extended to support other use cases, including:
-  * Alternate layer formats
-  * Immutable tags
-  * Selecting an artifact that refers to another manifest (e.g. signature or SBOM)
-  * Querying content from a pull through cache serving multiple registries (see [distribution-spec PR #66](https://github.com/opencontainers/distribution-spec/pull/66))
-* Provide backwards compatibility by using the existing reference convention from [distribution/reference](https://github.com/distribution/reference) when feasible.
+* Specify a standard that attempts to maximize compatibility with existing implementations.
+  * Provide backwards compatibility by using the existing reference convention from [distribution/reference](https://github.com/distribution/reference) when feasible.
+* Leverage existing RFCs for URI syntax where possible (see [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986)) to simplify implementations and integration with registries (a valid reference would be a subset of valid URIs).
+* Reserve specific syntaxes and URI features that may be used in the future versions.
+* Document how projects can safely extend the reference string in a way that will not conflict with future spec versions (e.g. using a project specific reverse DNS notation on key names).
+
+The working group will take into account future requirements of the spec, and minimize the risk of breaking changes from future releases.
+Example future requirements include:
+
+* Leveraging the scheme prefix (`oci://`) to reference content in other locations, such as an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/7b36cea86235157d78528944cb94c3323ee0905c/image-layout.md).
+* Passing query parameters after a tag/digest that could be sent to the upstream source (`?ttl=1d`).
+* Pushing immutable tags or tags with a limited retention time.
+* Pulling content directly from a pull through cache that serves multiple registries (see [distribution-spec PR #66](https://github.com/opencontainers/distribution-spec/pull/66))
+* Using anchors for client features (`#concurrent_blobs=2`).
 
 ## Out of Scope
 


### PR DESCRIPTION
I'd like to propose a new working group to create a `reference-spec` that would define a reference in OCI. At present, this is just a convention, originated by Docker, where `alpine` gets mapped to `docker.io/library/alpine:latest` (where `docker.io` isn't even the real registry name). There is currently an implementation for this in [distribution/distribution](https://github.com/distribution/distribution/tree/3e4f8a0ab1476a9516d02d76fbf869480541657f/reference) that many have used. I believe it would be useful for OCI to formalize this, and even include a Go implementation.

Other use cases I can think of (or have seen):

- [OCI Layout](https://sudo-bmitch.github.io/presentations/oci-layout/presentation.html#28) (both to entries with just a tag, and those with a full registry/repo:tag name in the index.json)
- [Immutable Tags](https://github.com/opencontainers/distribution-spec/pull/320#issuecomment-1165639590)
- Alternate layer formats like eStargz
- Querying for an artifact that refers another manifest (see [wg-reference-types](https://github.com/opencontainers/wg-reference-types) for more details)
- Querying content from a pull through cache serving multiple registries.

This PR will remain in draft state until there are a sufficient number of owners and stakeholders that volunteer to work on the project.

Signed-off-by: Brandon Mitchell <git@bmitch.net>