### PR TITLE
Reference types has finished, template update

### DIFF
--- a/WG-INFO.md
+++ b/WG-INFO.md
@@ -8,7 +8,9 @@
 
 ## List of disbanded OCI Working Groups
 
-* OCI Working Groups disbanded by the TOB will be listed here.
+* [Reference types](proposals/wg-reference-types.md) delivered the following changes:
+  * [image-spec PR #934](https://github.com/opencontainers/image-spec/pull/934)
+  * [distribution-spec PR #335](https://github.com/opencontainers/distribution-spec/pull/335)
 
 ## Required information for OCI Working Group Proposals
 

--- a/WG-TEMPLATE.md
+++ b/WG-TEMPLATE.md
@@ -24,6 +24,22 @@ The WG operates as an OCI Working Group under the [Open Container Initiative (OC
 
 * {Describe the intended work product and outputs of the WG, particularly indicating whether they consist of specification(s) and/or other project(s).}
 
+## Proposed Owners
+
+The following have agreed to participate in the working group, review progress, report progress back to the OCI community, and present the results to the TOB once the working group has completed its objectives.
+
+* {List proposed owners.}
+
+## Stakeholders
+
+OCI Projects, non-OCI projects, or organizations sponsoring the working group and participating in the implementation and use case validation of the work done by the group.
+
+* {List proposed stakeholders.}
+
+## Related Issues/PRs
+
+* {List any issues that would be resolved by this working group.}
+
 ## Governance
 
 * **Working Group**:


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

The reference types working group delivered their PRs. This documents that, and updates the template with some missing sections.