### PR TITLE
Update TOB for 2025 election

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -2,15 +2,17 @@
 
 We would like to acknowledge previous OCI TOB members and their huge contributions to our collective success:
 
-* Taylor Brown [Microsoft] (term date: 1/29/2018 - 1/29/2020)
-* Stephen Day [Cruise] (term date: 1/29/2018 - 1/29/2020)
-* Mrunal Patel [Red Hat] (term date: 1/29/2018 - 1/29/2020)
-* Michael Crosby [Apple] (term date: 1/29/2017 - 1/29/2021)
-* Wei Fu [Alibaba] (term date: 1/29/2020 - 1/29/2022)
-* Steve Lasker [Microsoft] (term date: 1/29/2020 - 1/29/2022)
-* Tycho Anderson [Cisco] (term date: 1/29/2021 - 1/29/2023)
-* Josh Dolitsky [Chainguard] (term date: 1/29/2022 - 1/29/2024)
-* Jon Johnson [Chainguard] (term date: 1/29/2022 - 1/29/2024)
-* Nisha Kumar [Oracle] (term date: 1/29/2022 - 1/29/2024)
+* Taylor Brown [Microsoft] (term finished: 1/29/2020)
+* Stephen Day [Cruise] (term finished: 1/29/2020)
+* Mrunal Patel [Red Hat] (term finished: 1/29/2020)
+* Michael Crosby [Apple] (term finished: 1/29/2021)
+* Wei Fu [Alibaba] (term finished: 1/29/2022)
+* Steve Lasker [Microsoft] (term finished: 1/29/2022)
+* Tycho Anderson [Cisco] (term finished: 1/29/2023)
+* Josh Dolitsky [Chainguard] (term finished: 1/29/2024)
+* Jon Johnson [Chainguard] (term finished: 1/29/2024)
+* Nisha Kumar [Oracle] (term finished: 1/29/2024)
+* Vincent Batts [Microsoft] (term finished: 1/29/2025)
+* Derek McGowan [Docker] (term finished: 1/29/2025)
 
 We thank these members for their service to the OCI community.

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ The TOB is responsible for managing conflicts, violations of procedures or guide
 
 ## Members
 
-* **Brandon Mitchell [Independent]** (term date: 1/29/2023 - 1/29/2025)
-* **Vincent Batts [Microsoft]** (term date: 1/29/2023 - 1/29/2025)
-* **Giuseppe Scrivano [Red Hat]** (term date: 1/29/2024 - 1/29/2026)
-* **Phil Estes [AWS]** (term date: 1/29/2022 - 1/29/2026)
-* **Ramkumar Chinchani [Cisco]** (term date: 1/29/2024 - 1/29/2026)
 * **Sajay Antony [Microsoft]** (term date: 1/29/2024 - 1/29/2026)
+* **Mike Brown [IBM]** (term date: 1/29/2025 - 1/29/2027)
+* **Ramkumar Chinchani [Cisco]** (term date: 1/29/2024 - 1/29/2026)
+* **Phil Estes [AWS]** (term date: 1/29/2022 - 1/29/2026)
+* **Tianon Gravi [Docker]** (term date: 1/29/2025 - 1/29/2027)
 * **Samuel Karp [Google]** (term date: 1/29/2022 - 1/29/2026) [Chair]
-* **Derek McGowan [Docker]** (term date: 1/29/2023 - 1/29/2025)
-* **Aleksa Sarai [SUSE]** (term date: 1/29/2023 - 1/29/2025)
+* **Brandon Mitchell [Independent]** (term date: 1/29/2025 - 1/29/2027)
+* **Aleksa Sarai [SUSE]** (term date: 1/29/2025 - 1/29/2027)
+* **Giuseppe Scrivano [Red Hat]** (term date: 1/29/2024 - 1/29/2026)
 
 ## Contact
 
 ### Mailing-list
 
-https://groups.google.com/a/opencontainers.org/forum/#!forum/tob (tob@opencontainers.org)
+<https://groups.google.com/a/opencontainers.org/forum/#!forum/tob> <tob@opencontainers.org>
 
 ### Github team
 


### PR DESCRIPTION
- Election is documented at https://github.com/opencontainers/tob/issues/145.
- Members were sorted alphabetical by last name.
- Emeritus updated to only show end date since many people served for much more than 2 years.

Fixes #145.