### PR TITLE
Fix start of term for Sam

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ The TOB is responsible for managing conflicts, violations of procedures or guide
 
 * **Sajay Antony [Microsoft]** (term date: 1/29/2026 - 1/29/2028)
 * **Mike Brown [IBM]** (term date: 1/29/2025 - 1/29/2027)
+* **Jeff Carter [Docker]** (term date: 1/29/2026 - 1/29/2028)
 * **Phil Estes [AWS]** (term date: 1/29/2026 - 1/29/2028)
 * **Tianon Gravi [Docker]** (term date: 1/29/2025 - 1/29/2027)
-* **Samuel Karp [Google]** (term date: 1/29/2022 - 1/29/2028)
+* **Samuel Karp [Google]** (term date: 1/29/2026 - 1/29/2028)
 * **Brandon Mitchell [Independent]** (term date: 1/29/2025 - 1/29/2027)
 * **Aleksa Sarai [Amutable]** (term date: 1/29/2025 - 1/29/2027)
-* **Jeff Carter [Docker]** (term date: 1/29/2026 - 1/29/2028)
 
 ## Contact
 


### PR DESCRIPTION
We haven't been tracking when members first started their term, only their current term start date. I'm also sorting entries by last name so we don't have any favoritism.